### PR TITLE
Update angles version and shasum

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-melodic-angles
 	pkgdesc = ROS - This package provides a set of simple math utilities to work with angles.
 	pkgver = 1.9.13
-	pkgrel = 2
+	pkgrel = 1
 	url = https://wiki.ros.org/angles
 	arch = any
 	license = BSD

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ros-melodic-angles
 	pkgdesc = ROS - This package provides a set of simple math utilities to work with angles.
-	pkgver = 1.9.11
+	pkgver = 1.9.13
 	pkgrel = 2
 	url = https://wiki.ros.org/angles
 	arch = any
@@ -8,8 +8,8 @@ pkgbase = ros-melodic-angles
 	makedepends = cmake
 	makedepends = ros-build-tools
 	makedepends = ros-melodic-catkin
-	source = ros-melodic-angles-1.9.11.tar.gz::https://github.com/ros/angles/archive/1.9.11.tar.gz
-	sha256sums = c453dc462585320e57e4086f47f3be618ec7a2e83610895ccfdbd31d5d4993f4
+	source = ros-melodic-angles-1.9.13.tar.gz::https://github.com/ros/angles/archive/1.9.13.tar.gz
+	sha256sums = 0e2982e9e4759614702f18f5c25cb7a0a88d382f4a4fab845ca1587305db2fd6
 
 pkgname = ros-melodic-angles
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,7 @@ pkgname='ros-melodic-angles'
 pkgver='1.9.13'
 _pkgver_patch=0
 arch=('any')
-pkgrel=2
+pkgrel=1
 license=('BSD')
 
 ros_makedepends=(

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@ pkgdesc="ROS - This package provides a set of simple math utilities to work with
 url='https://wiki.ros.org/angles'
 
 pkgname='ros-melodic-angles'
-pkgver='1.9.11'
+pkgver='1.9.13'
 _pkgver_patch=0
 arch=('any')
 pkgrel=2
@@ -29,7 +29,7 @@ depends=(
 
 _dir="angles-${pkgver}/angles"
 source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros/angles/archive/${pkgver}.tar.gz")
-sha256sums=('c453dc462585320e57e4086f47f3be618ec7a2e83610895ccfdbd31d5d4993f4')
+sha256sums=('0e2982e9e4759614702f18f5c25cb7a0a88d382f4a4fab845ca1587305db2fd6')
 
 build() {
 	# Use ROS environment variables.


### PR DESCRIPTION
Bumbed up to 1.9.13.

This is required if one e.g. has to use the `ros_controllers` package as they rely on the new `shortest_angular_distance_with_large_limits` function.